### PR TITLE
Limit streamed docker events to container events

### DIFF
--- a/src/docker-events.ts
+++ b/src/docker-events.ts
@@ -18,15 +18,12 @@ export function getEventStream(docker: Docker): EventEmitter {
     ])
 
     stream.on("data", (data) => {
-      const event = data.value
-      if (
-        event.Type !== "container" ||
-        (event.Action !== "start" && event.Action !== "stop")
-      ) {
+      const eventTypeAction = data.value.Type + data.value.Action
+      if (eventTypeAction !== "container.start" && eventTypeAction !== "container.stop") {
         return
       }
 
-      emitter.emit(`${event.Type}.${event.Action}`, data.value)
+      emitter.emit(eventTypeAction, data.value)
     })
   })
 

--- a/src/docker-events.ts
+++ b/src/docker-events.ts
@@ -19,6 +19,13 @@ export function getEventStream(docker: Docker): EventEmitter {
 
     stream.on("data", (data) => {
       const event = data.value
+      if (
+        event.Type !== "container" ||
+        (event.Action !== "start" && event.Action !== "stop")
+      ) {
+        return
+      }
+
       emitter.emit(`${event.Type}.${event.Action}`, data.value)
     })
   })

--- a/src/docker-events.ts
+++ b/src/docker-events.ts
@@ -7,7 +7,11 @@ import { parser } from "stream-json/jsonl/Parser"
 export function getEventStream(docker: Docker): EventEmitter {
   const emitter = new EventEmitter()
 
-  docker.getEvents((err, rawStream) => {
+  opts = {
+    type: "container",
+  }
+
+  docker.getEvents(opts, (err, rawStream) => {
     const stream = chain<any[]>([
       rawStream,
       parser()


### PR DESCRIPTION
We are only interested in container events (and not images, volumes, networks, services, nodes, secrets, configs, Docker reload or Builder events).

This fix should avoid overhead of emitting unneeded events.

https://docs.docker.com/reference/api/engine/version/v1.52/#tag/System/operation/SystemEvents